### PR TITLE
Fix renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,14 @@
     "config:best-practices",
     "schedule:weekly"
   ],
-  "python": {
-    "range": ">=3.13"
-  },
   "packageRules": [
+    {
+      "description": "Set Python version constraint",
+      "matchDatasources": ["pypi"],
+      "constraints": {
+        "python": ">=3.13"
+      }
+    },
     {
       "description": "Auto-merge patch and minor updates for dependencies",
       "matchUpdateTypes": ["patch", "minor"],
@@ -30,7 +34,7 @@
     "before 3am on Monday"
   ],
   "timezone": "UTC",
-  "semanticCommits": true,
+  "semanticCommits": "enabled",
   "prConcurrentLimit": 5,
   "vulnerabilityAlerts": {
     "labels": ["security"],


### PR DESCRIPTION
After https://github.com/johman10/profilarr-trash-guides/pull/15 the renovate config seems invalid. This PR aims to fix it.

It requires merging before it can be validated.