### PR TITLE
fix: Correct quality order and remux support

### DIFF
--- a/profiles/Radarr - (Anime) Remux-1080p.yml
+++ b/profiles/Radarr - (Anime) Remux-1080p.yml
@@ -66,34 +66,14 @@ custom_formats:
 - name: Radarr - VOSTFR
   score: -10000
 qualities:
-- id: 24
-  name: SDTV
-- id: 22
-  name: DVD
-- id: -4
-  name: WEB 480p
+- id: -1
+  name: Remux 1080p
   description: ''
   qualities:
-  - id: 20
-    name: WEBRip-480p
-  - id: 19
-    name: WEBDL-480p
-- id: 18
-  name: Bluray-480p
-- id: 17
-  name: Bluray-576p
-- id: -3
-  name: WEB 720p
-  description: ''
-  qualities:
-  - id: 16
-    name: HDTV-720p
-  - id: 15
-    name: WEBRip-720p
-  - id: 14
-    name: WEBDL-720p
-- id: 13
-  name: Bluray-720p
+  - id: null
+    name: Remux-1080p
+  - id: 10
+    name: Bluray-1080p
 - id: -2
   name: WEB 1080p
   description: ''
@@ -104,14 +84,34 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: -1
-  name: Remux 1080p
+- id: 13
+  name: Bluray-720p
+- id: -3
+  name: WEB 720p
   description: ''
   qualities:
-  - id: 8
-    name: Remux-1080p
-  - id: 10
-    name: Bluray-1080p
+  - id: 16
+    name: HDTV-720p
+  - id: 15
+    name: WEBRip-720p
+  - id: 14
+    name: WEBDL-720p
+- id: 17
+  name: Bluray-576p
+- id: 18
+  name: Bluray-480p
+- id: -4
+  name: WEB 480p
+  description: ''
+  qualities:
+  - id: 20
+    name: WEBRip-480p
+  - id: 19
+    name: WEBDL-480p
+- id: 22
+  name: DVD
+- id: 24
+  name: SDTV
 upgrade_until:
   id: -1
   name: Remux 1080p

--- a/profiles/Radarr - (Anime) Remux-1080p.yml
+++ b/profiles/Radarr - (Anime) Remux-1080p.yml
@@ -70,7 +70,7 @@ qualities:
   name: Remux 1080p
   description: ''
   qualities:
-  - id: null
+  - id: 8
     name: Remux-1080p
   - id: 10
     name: Bluray-1080p

--- a/profiles/Radarr - (French MULTi.VF) HD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VF) HD Bluray + WEB.yml
@@ -47,8 +47,6 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 13
-  name: Bluray-720p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -59,6 +57,8 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: 13
+  name: Bluray-720p
 upgrade_until:
   id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Radarr - (French MULTi.VF) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French MULTi.VF) HD Remux (1080p).yml
@@ -48,6 +48,8 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
+- id: null
+  name: Remux-1080p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -58,9 +60,7 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: 8
-  name: Remux-1080p
 upgrade_until:
-  id: 8
+  id: null
   name: Remux-1080p
 language: french

--- a/profiles/Radarr - (French MULTi.VF) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French MULTi.VF) HD Remux (1080p).yml
@@ -48,7 +48,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 8
   name: Remux-1080p
 - id: -1
   name: Bluray|WEB 1080p
@@ -61,6 +61,6 @@ qualities:
   - id: 9
     name: WEBDL-1080p
 upgrade_until:
-  id: null
+  id: 8
   name: Remux-1080p
 language: french

--- a/profiles/Radarr - (French MULTi.VF) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VF) UHD Bluray + WEB.yml
@@ -52,8 +52,6 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 8
-  name: Remux-1080p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -64,6 +62,8 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: null
+  name: Remux-1080p
 upgrade_until:
   id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Radarr - (French MULTi.VF) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VF) UHD Bluray + WEB.yml
@@ -62,7 +62,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: null
+- id: 8
   name: Remux-1080p
 upgrade_until:
   id: -1

--- a/profiles/Radarr - (French MULTi.VF) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French MULTi.VF) UHD Remux (2160p).yml
@@ -52,6 +52,8 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
+- id: null
+  name: Remux-2160p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -62,9 +64,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: 3
-  name: Remux-2160p
 upgrade_until:
-  id: 3
+  id: null
   name: Remux-2160p
 language: french

--- a/profiles/Radarr - (French MULTi.VF) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French MULTi.VF) UHD Remux (2160p).yml
@@ -52,7 +52,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 3
   name: Remux-2160p
 - id: -1
   name: Bluray|WEB 2160p
@@ -65,6 +65,6 @@ qualities:
   - id: 5
     name: WEBDL-2160p
 upgrade_until:
-  id: null
+  id: 3
   name: Remux-2160p
 language: french

--- a/profiles/Radarr - (French MULTi.VO) HD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VO) HD Bluray + WEB.yml
@@ -59,8 +59,6 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 13
-  name: Bluray-720p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -71,6 +69,8 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: 13
+  name: Bluray-720p
 upgrade_until:
   id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Radarr - (French MULTi.VO) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French MULTi.VO) HD Remux (1080p).yml
@@ -60,7 +60,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 8
   name: Remux-1080p
 - id: -1
   name: Bluray|WEB 1080p
@@ -73,6 +73,6 @@ qualities:
   - id: 9
     name: WEBDL-1080p
 upgrade_until:
-  id: null
+  id: 8
   name: Remux-1080p
 language: original

--- a/profiles/Radarr - (French MULTi.VO) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French MULTi.VO) HD Remux (1080p).yml
@@ -60,6 +60,8 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
+- id: null
+  name: Remux-1080p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -70,9 +72,7 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: 8
-  name: Remux-1080p
 upgrade_until:
-  id: 8
+  id: null
   name: Remux-1080p
 language: original

--- a/profiles/Radarr - (French MULTi.VO) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VO) UHD Bluray + WEB.yml
@@ -80,7 +80,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: null
+- id: 8
   name: Remux-1080p
 upgrade_until:
   id: -1

--- a/profiles/Radarr - (French MULTi.VO) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VO) UHD Bluray + WEB.yml
@@ -70,8 +70,6 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 8
-  name: Remux-1080p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -82,6 +80,8 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: null
+  name: Remux-1080p
 upgrade_until:
   id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Radarr - (French MULTi.VO) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French MULTi.VO) UHD Remux (2160p).yml
@@ -70,7 +70,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 3
   name: Remux-2160p
 - id: -1
   name: Bluray|WEB 2160p
@@ -83,6 +83,6 @@ qualities:
   - id: 5
     name: WEBDL-2160p
 upgrade_until:
-  id: null
+  id: 3
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - (French MULTi.VO) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French MULTi.VO) UHD Remux (2160p).yml
@@ -70,6 +70,8 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
+- id: null
+  name: Remux-2160p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -80,9 +82,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: 3
-  name: Remux-2160p
 upgrade_until:
-  id: 3
+  id: null
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - (French VOSTFR) HD Bluray + WEB.yml
+++ b/profiles/Radarr - (French VOSTFR) HD Bluray + WEB.yml
@@ -47,8 +47,6 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 13
-  name: Bluray-720p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -59,6 +57,8 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: 13
+  name: Bluray-720p
 upgrade_until:
   id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Radarr - (French VOSTFR) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French VOSTFR) HD Remux (1080p).yml
@@ -48,6 +48,8 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
+- id: null
+  name: Remux-1080p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -58,9 +60,7 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: 8
-  name: Remux-1080p
 upgrade_until:
-  id: 8
+  id: null
   name: Remux-1080p
 language: original

--- a/profiles/Radarr - (French VOSTFR) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French VOSTFR) HD Remux (1080p).yml
@@ -48,7 +48,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 8
   name: Remux-1080p
 - id: -1
   name: Bluray|WEB 1080p
@@ -61,6 +61,6 @@ qualities:
   - id: 9
     name: WEBDL-1080p
 upgrade_until:
-  id: null
+  id: 8
   name: Remux-1080p
 language: original

--- a/profiles/Radarr - (French VOSTFR) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French VOSTFR) UHD Bluray + WEB.yml
@@ -64,7 +64,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: null
+- id: 8
   name: Remux-1080p
 upgrade_until:
   id: -1

--- a/profiles/Radarr - (French VOSTFR) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French VOSTFR) UHD Bluray + WEB.yml
@@ -54,8 +54,6 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 8
-  name: Remux-1080p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -66,6 +64,8 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: null
+  name: Remux-1080p
 upgrade_until:
   id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Radarr - (French VOSTFR) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French VOSTFR) UHD Remux (2160p).yml
@@ -54,7 +54,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 3
   name: Remux-2160p
 - id: -1
   name: Bluray|WEB 2160p
@@ -67,6 +67,6 @@ qualities:
   - id: 5
     name: WEBDL-2160p
 upgrade_until:
-  id: null
+  id: 3
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - (French VOSTFR) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French VOSTFR) UHD Remux (2160p).yml
@@ -54,6 +54,8 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
+- id: null
+  name: Remux-2160p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -64,9 +66,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: 3
-  name: Remux-2160p
 upgrade_until:
-  id: 3
+  id: null
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - (German) HD Remux + WEB.yml
+++ b/profiles/Radarr - (German) HD Remux + WEB.yml
@@ -77,7 +77,7 @@ qualities:
   name: Merged QPs
   description: ''
   qualities:
-  - id: null
+  - id: 8
     name: Remux-1080p
   - id: 11
     name: WEBRip-1080p

--- a/profiles/Radarr - (German) HD Remux + WEB.yml
+++ b/profiles/Radarr - (German) HD Remux + WEB.yml
@@ -77,7 +77,7 @@ qualities:
   name: Merged QPs
   description: ''
   qualities:
-  - id: 8
+  - id: null
     name: Remux-1080p
   - id: 11
     name: WEBRip-1080p

--- a/profiles/Radarr - (German) Remux + WEB 2160p.yml
+++ b/profiles/Radarr - (German) Remux + WEB 2160p.yml
@@ -83,7 +83,7 @@ qualities:
   name: Merged QPs
   description: ''
   qualities:
-  - id: 3
+  - id: null
     name: Remux-2160p
   - id: 5
     name: WEBDL-2160p

--- a/profiles/Radarr - (German) Remux + WEB 2160p.yml
+++ b/profiles/Radarr - (German) Remux + WEB 2160p.yml
@@ -83,7 +83,7 @@ qualities:
   name: Merged QPs
   description: ''
   qualities:
-  - id: null
+  - id: 3
     name: Remux-2160p
   - id: 5
     name: WEBDL-2160p

--- a/profiles/Radarr - (SQP) SQP-1 (1080p).yml
+++ b/profiles/Radarr - (SQP) SQP-1 (1080p).yml
@@ -77,8 +77,6 @@ custom_formats:
 - name: Radarr - x265 (HD)
   score: -10000
 qualities:
-- id: 13
-  name: Bluray-720p
 - id: -1
   name: Bluray|WEB-1080p
   description: ''
@@ -93,6 +91,8 @@ qualities:
     name: WEBRip-720p
   - id: 14
     name: WEBDL-720p
+- id: 13
+  name: Bluray-720p
 upgrade_until:
   id: -1
   name: Bluray|WEB-1080p

--- a/profiles/Radarr - (SQP) SQP-1 (2160p).yml
+++ b/profiles/Radarr - (SQP) SQP-1 (2160p).yml
@@ -87,8 +87,16 @@ custom_formats:
 - name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
-- id: 13
-  name: Bluray-720p
+- id: 4
+  name: Bluray-2160p
+- id: -1
+  name: WEB 2160p
+  description: ''
+  qualities:
+  - id: 6
+    name: WEBRip-2160p
+  - id: 5
+    name: WEBDL-2160p
 - id: -2
   name: Bluray|WEB-1080p
   description: ''
@@ -103,16 +111,8 @@ qualities:
     name: WEBDL-720p
   - id: 15
     name: WEBRip-720p
-- id: -1
-  name: WEB 2160p
-  description: ''
-  qualities:
-  - id: 6
-    name: WEBRip-2160p
-  - id: 5
-    name: WEBDL-2160p
-- id: 4
-  name: Bluray-2160p
+- id: 13
+  name: Bluray-720p
 upgrade_until:
   id: 4
   name: Bluray-2160p

--- a/profiles/Radarr - (SQP) SQP-1 WEB (2160p).yml
+++ b/profiles/Radarr - (SQP) SQP-1 WEB (2160p).yml
@@ -89,16 +89,6 @@ custom_formats:
 - name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
-- id: -2
-  name: Bluray|WEB-1080p
-  description: ''
-  qualities:
-  - id: 10
-    name: Bluray-1080p
-  - id: 11
-    name: WEBRip-1080p
-  - id: 9
-    name: WEBDL-1080p
 - id: -1
   name: Bluray|WEB-2160p
   description: ''
@@ -109,6 +99,16 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: -2
+  name: Bluray|WEB-1080p
+  description: ''
+  qualities:
+  - id: 10
+    name: Bluray-1080p
+  - id: 11
+    name: WEBRip-1080p
+  - id: 9
+    name: WEBDL-1080p
 upgrade_until:
   id: -1
   name: Bluray|WEB-2160p

--- a/profiles/Radarr - (SQP) SQP-2.yml
+++ b/profiles/Radarr - (SQP) SQP-2.yml
@@ -67,7 +67,7 @@ qualities:
   qualities:
   - id: 4
     name: Bluray-2160p
-  - id: null
+  - id: 3
     name: Remux-2160p
   - id: 6
     name: WEBRip-2160p
@@ -77,7 +77,7 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: null
+- id: 8
   name: Remux-1080p
 upgrade_until:
   id: -1

--- a/profiles/Radarr - (SQP) SQP-2.yml
+++ b/profiles/Radarr - (SQP) SQP-2.yml
@@ -61,15 +61,13 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 8
-  name: Remux-1080p
 - id: -1
   name: WEB|Remux|Bluray|2160p
   description: ''
   qualities:
   - id: 4
     name: Bluray-2160p
-  - id: 3
+  - id: null
     name: Remux-2160p
   - id: 6
     name: WEBRip-2160p
@@ -79,6 +77,8 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: null
+  name: Remux-1080p
 upgrade_until:
   id: -1
   name: WEB|Remux|Bluray|2160p

--- a/profiles/Radarr - (SQP) SQP-3 (Audio).yml
+++ b/profiles/Radarr - (SQP) SQP-3 (Audio).yml
@@ -87,13 +87,13 @@ qualities:
   name: WEB|Remux|2160p
   description: ''
   qualities:
-  - id: null
+  - id: 3
     name: Remux-2160p
   - id: 5
     name: WEBDL-2160p
   - id: 6
     name: WEBRip-2160p
-  - id: null
+  - id: 8
     name: Remux-1080p
   - id: 9
     name: WEBDL-1080p

--- a/profiles/Radarr - (SQP) SQP-3 (Audio).yml
+++ b/profiles/Radarr - (SQP) SQP-3 (Audio).yml
@@ -87,13 +87,13 @@ qualities:
   name: WEB|Remux|2160p
   description: ''
   qualities:
-  - id: 3
+  - id: null
     name: Remux-2160p
   - id: 5
     name: WEBDL-2160p
   - id: 6
     name: WEBRip-2160p
-  - id: 8
+  - id: null
     name: Remux-1080p
   - id: 9
     name: WEBDL-1080p

--- a/profiles/Radarr - (SQP) SQP-3.yml
+++ b/profiles/Radarr - (SQP) SQP-3.yml
@@ -55,13 +55,11 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 8
-  name: Remux-1080p
 - id: -1
   name: WEB|Remux|2160p
   description: ''
   qualities:
-  - id: 3
+  - id: null
     name: Remux-2160p
   - id: 6
     name: WEBRip-2160p
@@ -71,6 +69,8 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: null
+  name: Remux-1080p
 upgrade_until:
   id: -1
   name: WEB|Remux|2160p

--- a/profiles/Radarr - (SQP) SQP-3.yml
+++ b/profiles/Radarr - (SQP) SQP-3.yml
@@ -59,7 +59,7 @@ qualities:
   name: WEB|Remux|2160p
   description: ''
   qualities:
-  - id: null
+  - id: 3
     name: Remux-2160p
   - id: 6
     name: WEBRip-2160p
@@ -69,7 +69,7 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: null
+- id: 8
   name: Remux-1080p
 upgrade_until:
   id: -1

--- a/profiles/Radarr - (SQP) SQP-4.yml
+++ b/profiles/Radarr - (SQP) SQP-4.yml
@@ -67,7 +67,7 @@ qualities:
     name: WEBDL-1080p
   - id: 11
     name: WEBRip-1080p
-- id: null
+- id: 8
   name: Remux-1080p
 upgrade_until:
   id: -1

--- a/profiles/Radarr - (SQP) SQP-4.yml
+++ b/profiles/Radarr - (SQP) SQP-4.yml
@@ -55,8 +55,6 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 8
-  name: Remux-1080p
 - id: -1
   name: WEB|2160p
   description: ''
@@ -69,6 +67,8 @@ qualities:
     name: WEBDL-1080p
   - id: 11
     name: WEBRip-1080p
+- id: null
+  name: Remux-1080p
 upgrade_until:
   id: -1
   name: WEB|2160p

--- a/profiles/Radarr - (SQP) SQP-5.yml
+++ b/profiles/Radarr - (SQP) SQP-5.yml
@@ -75,7 +75,7 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: null
+- id: 8
   name: Remux-1080p
 upgrade_until:
   id: -1

--- a/profiles/Radarr - (SQP) SQP-5.yml
+++ b/profiles/Radarr - (SQP) SQP-5.yml
@@ -61,8 +61,6 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 8
-  name: Remux-1080p
 - id: -1
   name: WEBDL|Bluray|2160p
   description: ''
@@ -77,6 +75,8 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: null
+  name: Remux-1080p
 upgrade_until:
   id: -1
   name: WEBDL|Bluray|2160p

--- a/profiles/Radarr - HD Bluray + WEB.yml
+++ b/profiles/Radarr - HD Bluray + WEB.yml
@@ -43,8 +43,8 @@ custom_formats:
 - name: Radarr - Sing-Along Versions
   score: -10000
 qualities:
-- id: 13
-  name: Bluray-720p
+- id: 10
+  name: Bluray-1080p
 - id: -1
   name: WEB 1080p
   description: ''
@@ -53,8 +53,8 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: 10
-  name: Bluray-1080p
+- id: 13
+  name: Bluray-720p
 upgrade_until:
   id: 10
   name: Bluray-1080p

--- a/profiles/Radarr - Remux + WEB 1080p.yml
+++ b/profiles/Radarr - Remux + WEB 1080p.yml
@@ -43,6 +43,8 @@ custom_formats:
 - name: Radarr - Sing-Along Versions
   score: -10000
 qualities:
+- id: null
+  name: Remux-1080p
 - id: -1
   name: WEB 1080p
   description: ''
@@ -51,9 +53,7 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: 8
-  name: Remux-1080p
 upgrade_until:
-  id: 8
+  id: null
   name: Remux-1080p
 language: original

--- a/profiles/Radarr - Remux + WEB 1080p.yml
+++ b/profiles/Radarr - Remux + WEB 1080p.yml
@@ -43,7 +43,7 @@ custom_formats:
 - name: Radarr - Sing-Along Versions
   score: -10000
 qualities:
-- id: null
+- id: 8
   name: Remux-1080p
 - id: -1
   name: WEB 1080p
@@ -54,6 +54,6 @@ qualities:
   - id: 9
     name: WEBDL-1080p
 upgrade_until:
-  id: null
+  id: 8
   name: Remux-1080p
 language: original

--- a/profiles/Radarr - Remux + WEB 2160p.yml
+++ b/profiles/Radarr - Remux + WEB 2160p.yml
@@ -45,6 +45,8 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
+- id: null
+  name: Remux-2160p
 - id: -1
   name: WEB 2160p
   description: ''
@@ -53,9 +55,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: 3
-  name: Remux-2160p
 upgrade_until:
-  id: 3
+  id: null
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - Remux + WEB 2160p.yml
+++ b/profiles/Radarr - Remux + WEB 2160p.yml
@@ -45,7 +45,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 3
   name: Remux-2160p
 - id: -1
   name: WEB 2160p
@@ -56,6 +56,6 @@ qualities:
   - id: 5
     name: WEBDL-2160p
 upgrade_until:
-  id: null
+  id: 3
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - Remux 2160p (Alternative).yml
+++ b/profiles/Radarr - Remux 2160p (Alternative).yml
@@ -59,7 +59,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 3
   name: Remux-2160p
 - id: 4
   name: Bluray-2160p
@@ -71,7 +71,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: null
+- id: 8
   name: Remux-1080p
 - id: 10
   name: Bluray-1080p
@@ -114,6 +114,6 @@ qualities:
 - id: 24
   name: SDTV
 upgrade_until:
-  id: null
+  id: 3
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - Remux 2160p (Alternative).yml
+++ b/profiles/Radarr - Remux 2160p (Alternative).yml
@@ -59,48 +59,10 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: 24
-  name: SDTV
-- id: 22
-  name: DVD
-- id: -4
-  name: WEB 480p
-  description: ''
-  qualities:
-  - id: 20
-    name: WEBRip-480p
-  - id: 19
-    name: WEBDL-480p
-- id: 18
-  name: Bluray-480p
-- id: 17
-  name: Bluray-576p
-- id: 16
-  name: HDTV-720p
-- id: -3
-  name: WEB 720p
-  description: ''
-  qualities:
-  - id: 15
-    name: WEBRip-720p
-  - id: 14
-    name: WEBDL-720p
-- id: 13
-  name: Bluray-720p
-- id: 12
-  name: HDTV-1080p
-- id: -2
-  name: WEB 1080p
-  description: ''
-  qualities:
-  - id: 11
-    name: WEBRip-1080p
-  - id: 9
-    name: WEBDL-1080p
-- id: 10
-  name: Bluray-1080p
-- id: 8
-  name: Remux-1080p
+- id: null
+  name: Remux-2160p
+- id: 4
+  name: Bluray-2160p
 - id: -1
   name: WEB 2160p
   description: ''
@@ -109,11 +71,49 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: 4
-  name: Bluray-2160p
-- id: 3
-  name: Remux-2160p
+- id: null
+  name: Remux-1080p
+- id: 10
+  name: Bluray-1080p
+- id: -2
+  name: WEB 1080p
+  description: ''
+  qualities:
+  - id: 11
+    name: WEBRip-1080p
+  - id: 9
+    name: WEBDL-1080p
+- id: 12
+  name: HDTV-1080p
+- id: 13
+  name: Bluray-720p
+- id: -3
+  name: WEB 720p
+  description: ''
+  qualities:
+  - id: 15
+    name: WEBRip-720p
+  - id: 14
+    name: WEBDL-720p
+- id: 16
+  name: HDTV-720p
+- id: 17
+  name: Bluray-576p
+- id: 18
+  name: Bluray-480p
+- id: -4
+  name: WEB 480p
+  description: ''
+  qualities:
+  - id: 20
+    name: WEBRip-480p
+  - id: 19
+    name: WEBDL-480p
+- id: 22
+  name: DVD
+- id: 24
+  name: SDTV
 upgrade_until:
-  id: 3
+  id: null
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - Remux 2160p (Combined).yml
+++ b/profiles/Radarr - Remux 2160p (Combined).yml
@@ -56,18 +56,10 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: -2
-  name: WEB 1080p
-  description: ''
-  qualities:
-  - id: 11
-    name: WEBRip-1080p
-  - id: 9
-    name: WEBDL-1080p
-- id: 10
-  name: Bluray-1080p
-- id: 8
-  name: Remux-1080p
+- id: null
+  name: Remux-2160p
+- id: 4
+  name: Bluray-2160p
 - id: -1
   name: WEB 2160p
   description: ''
@@ -76,11 +68,19 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: 4
-  name: Bluray-2160p
-- id: 3
-  name: Remux-2160p
+- id: null
+  name: Remux-1080p
+- id: 10
+  name: Bluray-1080p
+- id: -2
+  name: WEB 1080p
+  description: ''
+  qualities:
+  - id: 11
+    name: WEBRip-1080p
+  - id: 9
+    name: WEBDL-1080p
 upgrade_until:
-  id: 3
+  id: null
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - Remux 2160p (Combined).yml
+++ b/profiles/Radarr - Remux 2160p (Combined).yml
@@ -56,7 +56,7 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
-- id: null
+- id: 3
   name: Remux-2160p
 - id: 4
   name: Bluray-2160p
@@ -68,7 +68,7 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: null
+- id: 8
   name: Remux-1080p
 - id: 10
   name: Bluray-1080p
@@ -81,6 +81,6 @@ qualities:
   - id: 9
     name: WEBDL-1080p
 upgrade_until:
-  id: null
+  id: 3
   name: Remux-2160p
 language: original

--- a/profiles/Radarr - UHD Bluray + WEB.yml
+++ b/profiles/Radarr - UHD Bluray + WEB.yml
@@ -45,6 +45,8 @@ custom_formats:
 - name: Radarr - Upscaled
   score: -10000
 qualities:
+- id: 4
+  name: Bluray-2160p
 - id: -1
   name: WEB 2160p
   description: ''
@@ -53,8 +55,6 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
-- id: 4
-  name: Bluray-2160p
 upgrade_until:
   id: 4
   name: Bluray-2160p

--- a/profiles/Sonarr - (Anime) Remux-1080p.yml
+++ b/profiles/Sonarr - (Anime) Remux-1080p.yml
@@ -78,32 +78,14 @@ custom_formats:
 - name: Sonarr - VOSTFR
   score: -10000
 qualities:
-- id: 24
-  name: SDTV
-- id: 22
-  name: DVD
-- id: -4
-  name: WEB 480p
+- id: -1
+  name: Bluray 1080p
   description: ''
   qualities:
-  - id: 20
-    name: WEBRip-480p
-  - id: 19
-    name: WEBDL-480p
-- id: 18
-  name: Bluray-480p
-- id: -3
-  name: WEB 720p
-  description: ''
-  qualities:
-  - id: 16
-    name: HDTV-720p
-  - id: 15
-    name: WEBRip-720p
-  - id: 14
-    name: WEBDL-720p
-- id: 13
-  name: Bluray-720p
+  - id: 8
+    name: Bluray-1080p Remux
+  - id: 10
+    name: Bluray-1080p
 - id: -2
   name: WEB 1080p
   description: ''
@@ -114,14 +96,32 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
-- id: -1
-  name: Bluray 1080p
+- id: 13
+  name: Bluray-720p
+- id: -3
+  name: WEB 720p
   description: ''
   qualities:
-  - id: null
-    name: Bluray-1080p Remux
-  - id: 10
-    name: Bluray-1080p
+  - id: 16
+    name: HDTV-720p
+  - id: 15
+    name: WEBRip-720p
+  - id: 14
+    name: WEBDL-720p
+- id: 18
+  name: Bluray-480p
+- id: -4
+  name: WEB 480p
+  description: ''
+  qualities:
+  - id: 20
+    name: WEBRip-480p
+  - id: 19
+    name: WEBDL-480p
+- id: 22
+  name: DVD
+- id: 24
+  name: SDTV
 upgrade_until:
   id: -1
   name: Bluray 1080p

--- a/profiles/Sonarr - (Anime) Remux-1080p.yml
+++ b/profiles/Sonarr - (Anime) Remux-1080p.yml
@@ -82,7 +82,7 @@ qualities:
   name: Bluray 1080p
   description: ''
   qualities:
-  - id: null
+  - id: 8
     name: Bluray-1080p Remux
   - id: 10
     name: Bluray-1080p

--- a/profiles/Sonarr - (Anime) Remux-1080p.yml
+++ b/profiles/Sonarr - (Anime) Remux-1080p.yml
@@ -82,7 +82,7 @@ qualities:
   name: Bluray 1080p
   description: ''
   qualities:
-  - id: 8
+  - id: null
     name: Bluray-1080p Remux
   - id: 10
     name: Bluray-1080p

--- a/profiles/Sonarr - (French MULTi.VF) HD Bluray + WEB (1080p).yml
+++ b/profiles/Sonarr - (French MULTi.VF) HD Bluray + WEB (1080p).yml
@@ -44,16 +44,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: -2
-  name: Bluray|WEB 720p
-  description: ''
-  qualities:
-  - id: 13
-    name: Bluray-720p
-  - id: 15
-    name: WEBRip-720p
-  - id: 14
-    name: WEBDL-720p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -64,6 +54,16 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: -2
+  name: Bluray|WEB 720p
+  description: ''
+  qualities:
+  - id: 13
+    name: Bluray-720p
+  - id: 15
+    name: WEBRip-720p
+  - id: 14
+    name: WEBDL-720p
 upgrade_until:
   id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Sonarr - (French MULTi.VF) UHD Bluray + WEB (2160p).yml
+++ b/profiles/Sonarr - (French MULTi.VF) UHD Bluray + WEB (2160p).yml
@@ -48,16 +48,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: -2
-  name: Bluray|WEB 1080p
-  description: ''
-  qualities:
-  - id: 10
-    name: Bluray-1080p
-  - id: 11
-    name: WEBRip-1080p
-  - id: 9
-    name: WEBDL-1080p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -68,6 +58,16 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: -2
+  name: Bluray|WEB 1080p
+  description: ''
+  qualities:
+  - id: 10
+    name: Bluray-1080p
+  - id: 11
+    name: WEBRip-1080p
+  - id: 9
+    name: WEBDL-1080p
 upgrade_until:
   id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Sonarr - (French MULTi.VO) HD Bluray + WEB (1080p).yml
+++ b/profiles/Sonarr - (French MULTi.VO) HD Bluray + WEB (1080p).yml
@@ -56,16 +56,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: -2
-  name: Bluray|WEB 720p
-  description: ''
-  qualities:
-  - id: 13
-    name: Bluray-720p
-  - id: 15
-    name: WEBRip-720p
-  - id: 14
-    name: WEBDL-720p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -76,6 +66,16 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: -2
+  name: Bluray|WEB 720p
+  description: ''
+  qualities:
+  - id: 13
+    name: Bluray-720p
+  - id: 15
+    name: WEBRip-720p
+  - id: 14
+    name: WEBDL-720p
 upgrade_until:
   id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Sonarr - (French MULTi.VO) UHD Bluray + WEB (2160p).yml
+++ b/profiles/Sonarr - (French MULTi.VO) UHD Bluray + WEB (2160p).yml
@@ -60,16 +60,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: -2
-  name: Bluray|WEB 1080p
-  description: ''
-  qualities:
-  - id: 10
-    name: Bluray-1080p
-  - id: 11
-    name: WEBRip-1080p
-  - id: 9
-    name: WEBDL-1080p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -80,6 +70,16 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: -2
+  name: Bluray|WEB 1080p
+  description: ''
+  qualities:
+  - id: 10
+    name: Bluray-1080p
+  - id: 11
+    name: WEBRip-1080p
+  - id: 9
+    name: WEBDL-1080p
 upgrade_until:
   id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Sonarr - (French VOSTFR) HD Bluray + WEB (1080p).yml
+++ b/profiles/Sonarr - (French VOSTFR) HD Bluray + WEB (1080p).yml
@@ -44,16 +44,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: -2
-  name: Bluray|WEB 720p
-  description: ''
-  qualities:
-  - id: 13
-    name: Bluray-720p
-  - id: 15
-    name: WEBRip-720p
-  - id: 14
-    name: WEBDL-720p
 - id: -1
   name: Bluray|WEB 1080p
   description: ''
@@ -64,6 +54,16 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: -2
+  name: Bluray|WEB 720p
+  description: ''
+  qualities:
+  - id: 13
+    name: Bluray-720p
+  - id: 15
+    name: WEBRip-720p
+  - id: 14
+    name: WEBDL-720p
 upgrade_until:
   id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Sonarr - (French VOSTFR) UHD Bluray + WEB (2160p).yml
+++ b/profiles/Sonarr - (French VOSTFR) UHD Bluray + WEB (2160p).yml
@@ -48,16 +48,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: -2
-  name: Bluray|WEB 1080p
-  description: ''
-  qualities:
-  - id: 10
-    name: Bluray-1080p
-  - id: 11
-    name: WEBRip-1080p
-  - id: 9
-    name: WEBDL-1080p
 - id: -1
   name: Bluray|WEB 2160p
   description: ''
@@ -68,6 +58,16 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: -2
+  name: Bluray|WEB 1080p
+  description: ''
+  qualities:
+  - id: 10
+    name: Bluray-1080p
+  - id: 11
+    name: WEBRip-1080p
+  - id: 9
+    name: WEBDL-1080p
 upgrade_until:
   id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Sonarr - (German) HD Remux + WEB.yml
+++ b/profiles/Sonarr - (German) HD Remux + WEB.yml
@@ -69,7 +69,7 @@ qualities:
   name: Merged QPs
   description: ''
   qualities:
-  - id: null
+  - id: 8
     name: Bluray-1080p Remux
   - id: 11
     name: WEBRip-1080p

--- a/profiles/Sonarr - (German) HD Remux + WEB.yml
+++ b/profiles/Sonarr - (German) HD Remux + WEB.yml
@@ -69,7 +69,7 @@ qualities:
   name: Merged QPs
   description: ''
   qualities:
-  - id: 8
+  - id: null
     name: Bluray-1080p Remux
   - id: 11
     name: WEBRip-1080p

--- a/profiles/Sonarr - (German) UHD Remux + WEB.yml
+++ b/profiles/Sonarr - (German) UHD Remux + WEB.yml
@@ -73,7 +73,7 @@ qualities:
   name: Merged QPs
   description: ''
   qualities:
-  - id: null
+  - id: 3
     name: Bluray-2160p Remux
   - id: 5
     name: WEBDL-2160p

--- a/profiles/Sonarr - (German) UHD Remux + WEB.yml
+++ b/profiles/Sonarr - (German) UHD Remux + WEB.yml
@@ -73,7 +73,7 @@ qualities:
   name: Merged QPs
   description: ''
   qualities:
-  - id: 3
+  - id: null
     name: Bluray-2160p Remux
   - id: 5
     name: WEBDL-2160p

--- a/profiles/Sonarr - WEB-1080p (Alternative).yml
+++ b/profiles/Sonarr - WEB-1080p (Alternative).yml
@@ -36,38 +36,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: 24
-  name: SDTV
-- id: 22
-  name: DVD
-- id: 18
-  name: Bluray-480p
-- id: -3
-  name: WEB 480p
-  description: ''
-  qualities:
-  - id: 20
-    name: WEBRip-480p
-  - id: 19
-    name: WEBDL-480p
-- id: 17
-  name: Bluray-576p
-- id: 16
-  name: HDTV-720p
-- id: 13
-  name: Bluray-720p
-- id: -2
-  name: WEB 720p
-  description: ''
-  qualities:
-  - id: 15
-    name: WEBRip-720p
-  - id: 14
-    name: WEBDL-720p
-- id: 12
-  name: HDTV-1080p
-- id: 10
-  name: Bluray-1080p
 - id: -1
   name: WEB 1080p
   description: ''
@@ -76,6 +44,38 @@ qualities:
     name: WEBRip-1080p
   - id: 9
     name: WEBDL-1080p
+- id: 10
+  name: Bluray-1080p
+- id: 12
+  name: HDTV-1080p
+- id: -2
+  name: WEB 720p
+  description: ''
+  qualities:
+  - id: 15
+    name: WEBRip-720p
+  - id: 14
+    name: WEBDL-720p
+- id: 13
+  name: Bluray-720p
+- id: 16
+  name: HDTV-720p
+- id: 17
+  name: Bluray-576p
+- id: -3
+  name: WEB 480p
+  description: ''
+  qualities:
+  - id: 20
+    name: WEBRip-480p
+  - id: 19
+    name: WEBDL-480p
+- id: 18
+  name: Bluray-480p
+- id: 22
+  name: DVD
+- id: 24
+  name: SDTV
 upgrade_until:
   id: -1
   name: WEB 1080p

--- a/profiles/Sonarr - WEB-2160p (Alternative).yml
+++ b/profiles/Sonarr - WEB-2160p (Alternative).yml
@@ -38,48 +38,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: 24
-  name: SDTV
-- id: 22
-  name: DVD
-- id: 18
-  name: Bluray-480p
-- id: -4
-  name: WEB 480p
-  description: ''
-  qualities:
-  - id: 20
-    name: WEBRip-480p
-  - id: 19
-    name: WEBDL-480p
-- id: 17
-  name: Bluray-576p
-- id: 16
-  name: HDTV-720p
-- id: 13
-  name: Bluray-720p
-- id: -3
-  name: WEB 720p
-  description: ''
-  qualities:
-  - id: 15
-    name: WEBRip-720p
-  - id: 14
-    name: WEBDL-720p
-- id: 12
-  name: HDTV-1080p
-- id: 10
-  name: Bluray-1080p
-- id: -2
-  name: WEB 1080p
-  description: ''
-  qualities:
-  - id: 11
-    name: WEBRip-1080p
-  - id: 9
-    name: WEBDL-1080p
-- id: 4
-  name: Bluray-2160p
 - id: -1
   name: WEB 2160p
   description: ''
@@ -88,6 +46,48 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: 4
+  name: Bluray-2160p
+- id: -2
+  name: WEB 1080p
+  description: ''
+  qualities:
+  - id: 11
+    name: WEBRip-1080p
+  - id: 9
+    name: WEBDL-1080p
+- id: 10
+  name: Bluray-1080p
+- id: 12
+  name: HDTV-1080p
+- id: -3
+  name: WEB 720p
+  description: ''
+  qualities:
+  - id: 15
+    name: WEBRip-720p
+  - id: 14
+    name: WEBDL-720p
+- id: 13
+  name: Bluray-720p
+- id: 16
+  name: HDTV-720p
+- id: 17
+  name: Bluray-576p
+- id: -4
+  name: WEB 480p
+  description: ''
+  qualities:
+  - id: 20
+    name: WEBRip-480p
+  - id: 19
+    name: WEBDL-480p
+- id: 18
+  name: Bluray-480p
+- id: 22
+  name: DVD
+- id: 24
+  name: SDTV
 upgrade_until:
   id: -1
   name: WEB 2160p

--- a/profiles/Sonarr - WEB-2160p (Combined).yml
+++ b/profiles/Sonarr - WEB-2160p (Combined).yml
@@ -37,14 +37,6 @@ custom_formats:
 - name: Sonarr - LQ (Release Title)
   score: -10000
 qualities:
-- id: -2
-  name: WEB 1080p
-  description: ''
-  qualities:
-  - id: 11
-    name: WEBRip-1080p
-  - id: 9
-    name: WEBDL-1080p
 - id: -1
   name: WEB 2160p
   description: ''
@@ -53,6 +45,14 @@ qualities:
     name: WEBRip-2160p
   - id: 5
     name: WEBDL-2160p
+- id: -2
+  name: WEB 1080p
+  description: ''
+  qualities:
+  - id: 11
+    name: WEBRip-1080p
+  - id: 9
+    name: WEBDL-1080p
 upgrade_until:
   id: -1
   name: WEB 2160p

--- a/scripts/utils/mappings/qualities.py
+++ b/scripts/utils/mappings/qualities.py
@@ -4,209 +4,224 @@ QUALITIES = [
         "name": "Raw-HD",
         "description": "Uncompressed, high definition recorded video from airing",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 2,
         "name": "BR-Disk",
         "description": "Complete Blu-ray disc image",
         "radarr": True,
-        "sonarr": False,
+        "sonarr": False
     },
     {
         "id": 3,
-        "name": "Bluray-2160p Remux",
-        "description": "4K Ultra HD Blu-ray disc content remuxed into a playable file format",
+        "name": "Remux-2160p",
+        "description":
+            "4K Ultra HD Blu-ray disc content remuxed into a playable file format",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 4,
         "name": "Bluray-2160p",
         "description": "4K Ultra HD Blu-ray video encoded with lossy compression",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 5,
         "name": "WEBDL-2160p",
-        "description": "4K web download, untouched as released by the streaming service",
+        "description":
+            "4K web download, untouched as released by the streaming service",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 6,
         "name": "WEBRip-2160p",
-        "description": "4K web rip, either captured from a 4K WEB-DL using a capture card or re-encoded from a 4K WEB-DL",
+        "description":
+            "4K web rip, either captured from a 4K WEB-DL using a capture card or re-encoded from a 4K WEB-DL",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 7,
         "name": "HDTV-2160p",
         "description": "4K high-definition digital television capture",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 8,
-        "name": "Bluray-1080p Remux",
-        "description": "1080p Blu-ray disc content remuxed into a playable file format",
+        "name": "Remux-1080p",
+        "description":
+            "1080p Blu-ray disc content remuxed into a playable file format",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 9,
         "name": "WEBDL-1080p",
-        "description": "1080p web download, untouched as released by the streaming service",
+        "description":
+            "1080p web download, untouched as released by the streaming service",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 10,
         "name": "Bluray-1080p",
         "description": "1080p Blu-ray video encoded with lossy compression",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 11,
         "name": "WEBRip-1080p",
-        "description": "1080p web rip, either captured using a capture card or re-encoded from a WEB-DL of equal or higher resolution",
+        "description":
+            "1080p web rip, either captured using a capture card or re-encoded from a WEB-DL of equal or higher resolution",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 12,
         "name": "HDTV-1080p",
         "description": "1080p high-definition digital television capture",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 13,
         "name": "Bluray-720p",
         "description": "720p Blu-ray video encoded with lossy compression",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 14,
         "name": "WEBDL-720p",
-        "description": "720p web download, untouched as released by the streaming service",
+        "description":
+            "720p web download, untouched as released by the streaming service",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 15,
         "name": "WEBRip-720p",
-        "description": "720p web rip, either captured using a capture card or re-encoded from a WEB-DL of equal or higher resolution",
+        "description":
+            "720p web rip, either captured using a capture card or re-encoded from a WEB-DL of equal or higher resolution",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 16,
         "name": "HDTV-720p",
         "description": "720p high-definition digital television capture",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 17,
         "name": "Bluray-576p",
         "description": "576p Blu-ray video encoded with lossy compression",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 18,
         "name": "Bluray-480p",
         "description": "480p Blu-ray video encoded with lossy compression",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 19,
         "name": "WEBDL-480p",
-        "description": "480p web download, untouched as released by the streaming service",
+        "description":
+            "480p web download, untouched as released by the streaming service",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 20,
         "name": "WEBRip-480p",
-        "description": "480p web rip, either captured using a capture card or re-encoded from a WEB-DL of equal or higher resolution",
+        "description":
+            "480p web rip, either captured using a capture card or re-encoded from a WEB-DL of equal or higher resolution",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 21,
         "name": "DVD-R",
         "description": "DVD-Video disc image",
         "radarr": True,
-        "sonarr": False,
+        "sonarr": False
     },
     {
         "id": 22,
         "name": "DVD",
         "description": "Standard DVD video, usually encoded at 480p",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 23,
         "name": "DVDSCR",
         "description": "DVD screener, usually a lower quality early release",
         "radarr": True,
-        "sonarr": False,
+        "sonarr": False
     },
     {
         "id": 24,
         "name": "SDTV",
-        "description": "Standard-definition digital television capture, typically 480p or lower",
+        "description":
+            "Standard-definition digital television capture, typically 480p or lower",
         "radarr": True,
-        "sonarr": True,
+        "sonarr": True
     },
     {
         "id": 25,
         "name": "Telecine",
-        "description": "Movie captured from a film print using a telecine machine",
+        "description":
+            "Movie captured from a film print using a telecine machine",
         "radarr": True,
-        "sonarr": False,
+        "sonarr": False
     },
     {
         "id": 26,
         "name": "Telesync",
-        "description": "Filmed in a movie theater using a professional camera, often with external audio",
+        "description":
+            "Filmed in a movie theater using a professional camera, often with external audio",
         "radarr": True,
-        "sonarr": False,
+        "sonarr": False
     },
     {
         "id": 27,
         "name": "REGIONAL",
         "description": "A release intended for a specific geographic region",
         "radarr": True,
-        "sonarr": False,
+        "sonarr": False
     },
     {
         "id": 28,
         "name": "WORKPRINT",
-        "description": "An unfinished version of a movie, often with incomplete special effects",
+        "description":
+            "An unfinished version of a movie, often with incomplete special effects",
         "radarr": True,
-        "sonarr": False,
+        "sonarr": False
     },
     {
         "id": 29,
         "name": "CAM",
-        "description": "Filmed in a movie theater using a camcorder or mobile phone",
+        "description":
+            "Filmed in a movie theater using a camcorder or mobile phone",
         "radarr": True,
-        "sonarr": False,
+        "sonarr": False
     },
     {
         "id": 30,
         "name": "Unknown",
         "description": "Quality or source is unknown or unspecified",
         "radarr": True,
-        "sonarr": True,
-    },
+        "sonarr": True
+    }
 ]

--- a/scripts/utils/mappings/qualities.py
+++ b/scripts/utils/mappings/qualities.py
@@ -1,3 +1,12 @@
+SERVICE_QUALITY_TO_PROFILARR_QUALITY = {
+    "sonarr": {
+        "Bluray-1080p Remux": "Remux-1080p",
+        "Bluray-2160p Remux": "Remux-2160p",
+    },
+    "radarr": {},
+}
+
+
 QUALITIES = [
     {
         "id": 1,

--- a/scripts/utils/mappings/qualities.py
+++ b/scripts/utils/mappings/qualities.py
@@ -15,7 +15,7 @@ QUALITIES = [
     },
     {
         "id": 3,
-        "name": "Remux-2160p",
+        "name": "Bluray-2160p Remux",
         "description": "4K Ultra HD Blu-ray disc content remuxed into a playable file format",
         "radarr": True,
         "sonarr": True,
@@ -50,7 +50,7 @@ QUALITIES = [
     },
     {
         "id": 8,
-        "name": "Remux-1080p",
+        "name": "Bluray-1080p Remux",
         "description": "1080p Blu-ray disc content remuxed into a playable file format",
         "radarr": True,
         "sonarr": True,

--- a/scripts/utils/profiles.py
+++ b/scripts/utils/profiles.py
@@ -4,7 +4,7 @@ import yaml
 from markdownify import markdownify
 
 from utils.file_utils import iterate_json_files
-from utils.mappings.qualities import QUALITIES
+from utils.mappings.qualities import QUALITIES, SERVICE_QUALITY_TO_PROFILARR_QUALITY
 from utils.strings import get_name
 
 
@@ -29,32 +29,42 @@ def _collect_profile_formats(
     )
 
 
-def _get_quality_id(quality_name):
+def _get_quality_id(service, quality_name):
+    safe_quality_name = SERVICE_QUALITY_TO_PROFILARR_QUALITY[service].get(
+        quality_name, quality_name
+    )
     return next(
-        (quality["id"] for quality in QUALITIES if quality["name"] == quality_name),
-        None,
+        (
+            quality["id"]
+            for quality in QUALITIES
+            if quality["name"] == safe_quality_name
+        )
     )
 
 
-def _collect_qualities(items):
+def _collect_qualities(service, items):
     qualities = []
     quality_collection_id = -1
     for item in items:
         if item.get("allowed", False) is False:
             continue
 
+        quality_id = (
+            _get_quality_id(service, item.get("name", ""))
+            if item.get("items") is None
+            else quality_collection_id
+        )
         quality = {
-            "id": _get_quality_id(item.get("name", "")),
+            "id": quality_id,
             "name": item.get("name", ""),
         }
         if item.get("items") is not None:
-            quality["id"] = quality_collection_id
             quality_collection_id -= 1
             quality["description"] = ""
             quality["qualities"] = []
             for sub_item in item["items"]:
                 quality["qualities"].append(
-                    {"id": _get_quality_id(sub_item), "name": sub_item}
+                    {"id": _get_quality_id(service, sub_item), "name": sub_item}
                 )
         qualities.append(quality)
 
@@ -76,7 +86,7 @@ def _get_upgrade_until(quality_name, profile_qualities):
 def _collect_profile(service, input_json, output_dir, trash_id_to_scoring_mapping):
     # Compose YAML structure
     name = input_json.get("name", "")
-    profile_qualities = _collect_qualities(input_json.get("items", []))
+    profile_qualities = _collect_qualities(service, input_json.get("items", []))
     yml_data = {
         "name": get_name(service, name),
         "description": f"""[Profile from TRaSH-Guides.](https://trash-guides.info/{service.capitalize()}/{service}-setup-quality-profiles)

--- a/scripts/utils/profiles.py
+++ b/scripts/utils/profiles.py
@@ -58,7 +58,7 @@ def _collect_qualities(items):
                 )
         qualities.append(quality)
 
-    return list(reversed(qualities))
+    return list(qualities)
 
 
 def _get_upgrade_until(quality_name, profile_qualities):


### PR DESCRIPTION
This resolves: #26. It also updates the list of quality ids based https://github.com/BiluliB/profilarr/blob/53d7b4ab01c827dd2d35fc2c98c0d0aa9fdfddf6/frontend/src/constants/qualities.js#L118 to prevent `null`. In the future the build will fail if the quality is not found in the quality mapping.