### PR TITLE
Add support for Custom Format Groups

### DIFF
--- a/profiles/Radarr - (French MULTi.VF) HD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VF) HD Bluray + WEB.yml
@@ -46,6 +46,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Radarr - (French MULTi.VF) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French MULTi.VF) HD Remux (1080p).yml
@@ -47,6 +47,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 qualities:
 - id: 8
   name: Remux-1080p

--- a/profiles/Radarr - (French MULTi.VF) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VF) UHD Bluray + WEB.yml
@@ -51,6 +51,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Radarr - (French MULTi.VF) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French MULTi.VF) UHD Remux (2160p).yml
@@ -51,6 +51,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: 3
   name: Remux-2160p

--- a/profiles/Radarr - (French MULTi.VO) HD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VO) HD Bluray + WEB.yml
@@ -58,6 +58,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Radarr - (French MULTi.VO) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French MULTi.VO) HD Remux (1080p).yml
@@ -59,6 +59,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 qualities:
 - id: 8
   name: Remux-1080p

--- a/profiles/Radarr - (French MULTi.VO) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French MULTi.VO) UHD Bluray + WEB.yml
@@ -69,6 +69,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Radarr - (French MULTi.VO) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French MULTi.VO) UHD Remux (2160p).yml
@@ -69,6 +69,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: 3
   name: Remux-2160p

--- a/profiles/Radarr - (French VOSTFR) HD Bluray + WEB.yml
+++ b/profiles/Radarr - (French VOSTFR) HD Bluray + WEB.yml
@@ -46,6 +46,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Radarr - (French VOSTFR) HD Remux (1080p).yml
+++ b/profiles/Radarr - (French VOSTFR) HD Remux (1080p).yml
@@ -47,6 +47,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 qualities:
 - id: 8
   name: Remux-1080p

--- a/profiles/Radarr - (French VOSTFR) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (French VOSTFR) UHD Bluray + WEB.yml
@@ -53,6 +53,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Radarr - (French VOSTFR) UHD Remux (2160p).yml
+++ b/profiles/Radarr - (French VOSTFR) UHD Remux (2160p).yml
@@ -53,6 +53,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Upscaled
   score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: 3
   name: Remux-2160p

--- a/profiles/Radarr - (German) Anime HD Bluray + WEB.yml
+++ b/profiles/Radarr - (German) Anime HD Bluray + WEB.yml
@@ -93,6 +93,28 @@ custom_formats:
   score: 1
 - name: Radarr - v0
   score: -51
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
 - name: Radarr - Anime LQ Groups
   score: -35000
 - name: Radarr - Anime Raws

--- a/profiles/Radarr - (German) Anime HD Bluray + WEB.yml
+++ b/profiles/Radarr - (German) Anime HD Bluray + WEB.yml
@@ -93,31 +93,23 @@ custom_formats:
   score: 1
 - name: Radarr - v0
   score: -51
-- name: Radarr - 3D
-  score: -10000
-- name: Radarr - AV1
-  score: -10000
 - name: Radarr - Bad Dual Groups
   score: -10000
 - name: Radarr - Black and White Editions
   score: -10000
-- name: Radarr - BR-DISK
-  score: -10000
-- name: Radarr - Extras
-  score: -10000
-- name: Radarr - Generated Dynamic HDR
-  score: -10000
-- name: Radarr - LQ
-  score: -10000
-- name: Radarr - LQ (Release Title)
-  score: -10000
 - name: Radarr - Sing-Along Versions
   score: -10000
-- name: Radarr - Upscaled
-  score: -10000
+- name: Radarr - 3D
+  score: -35000
 - name: Radarr - Anime LQ Groups
   score: -35000
 - name: Radarr - Anime Raws
+  score: -35000
+- name: Radarr - AV1
+  score: -35000
+- name: Radarr - BR-DISK
+  score: -35000
+- name: Radarr - Extras
   score: -35000
 - name: Radarr - German LQ
   score: -35000
@@ -127,7 +119,13 @@ custom_formats:
   score: -35000
 - name: Radarr - Line-Mic Dubbed
   score: -35000
+- name: Radarr - LQ
+  score: -35000
+- name: Radarr - LQ (Release Title)
+  score: -35000
 - name: Radarr - Not German, Japanese or English
+  score: -35000
+- name: Radarr - Upscaled
   score: -35000
 - name: Radarr - VOSTFR
   score: -35000

--- a/profiles/Radarr - (German) HD Bluray + WEB.yml
+++ b/profiles/Radarr - (German) HD Bluray + WEB.yml
@@ -53,30 +53,20 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
-- name: Radarr - 3D
-  score: -10000
-- name: Radarr - AV1
-  score: -10000
-- name: Radarr - Bad Dual Groups
-  score: -10000
 - name: Radarr - Black and White Editions
-  score: -10000
-- name: Radarr - BR-DISK
-  score: -10000
-- name: Radarr - Extras
-  score: -10000
-- name: Radarr - Generated Dynamic HDR
-  score: -10000
-- name: Radarr - LQ
-  score: -10000
-- name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
   score: -10000
-- name: Radarr - Upscaled
-  score: -10000
-- name: Radarr - x265 (HD)
-  score: -10000
+- name: Radarr - 3D
+  score: -35000
+- name: Radarr - AV1
+  score: -35000
+- name: Radarr - Bad Dual Groups
+  score: -35000
+- name: Radarr - BR-DISK
+  score: -35000
+- name: Radarr - Extras
+  score: -35000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)
@@ -85,7 +75,13 @@ custom_formats:
   score: -35000
 - name: Radarr - Line-Mic Dubbed
   score: -35000
+- name: Radarr - LQ
+  score: -35000
+- name: Radarr - LQ (Release Title)
+  score: -35000
 - name: Radarr - Not German or English
+  score: -35000
+- name: Radarr - Upscaled
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Radarr - (German) HD Bluray + WEB.yml
+++ b/profiles/Radarr - (German) HD Bluray + WEB.yml
@@ -53,6 +53,30 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)

--- a/profiles/Radarr - (German) HD Remux + WEB.yml
+++ b/profiles/Radarr - (German) HD Remux + WEB.yml
@@ -50,30 +50,20 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
-- name: Radarr - 3D
-  score: -10000
-- name: Radarr - AV1
-  score: -10000
-- name: Radarr - Bad Dual Groups
-  score: -10000
 - name: Radarr - Black and White Editions
-  score: -10000
-- name: Radarr - BR-DISK
-  score: -10000
-- name: Radarr - Extras
-  score: -10000
-- name: Radarr - Generated Dynamic HDR
-  score: -10000
-- name: Radarr - LQ
-  score: -10000
-- name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
   score: -10000
-- name: Radarr - Upscaled
-  score: -10000
-- name: Radarr - x265 (HD)
-  score: -10000
+- name: Radarr - 3D
+  score: -35000
+- name: Radarr - AV1
+  score: -35000
+- name: Radarr - Bad Dual Groups
+  score: -35000
+- name: Radarr - BR-DISK
+  score: -35000
+- name: Radarr - Extras
+  score: -35000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)
@@ -82,7 +72,13 @@ custom_formats:
   score: -35000
 - name: Radarr - Line-Mic Dubbed
   score: -35000
+- name: Radarr - LQ
+  score: -35000
+- name: Radarr - LQ (Release Title)
+  score: -35000
 - name: Radarr - Not German or English
+  score: -35000
+- name: Radarr - Upscaled
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Radarr - (German) HD Remux + WEB.yml
+++ b/profiles/Radarr - (German) HD Remux + WEB.yml
@@ -50,6 +50,30 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)

--- a/profiles/Radarr - (German) Remux + WEB 2160p.yml
+++ b/profiles/Radarr - (German) Remux + WEB 2160p.yml
@@ -54,6 +54,30 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)

--- a/profiles/Radarr - (German) Remux + WEB 2160p.yml
+++ b/profiles/Radarr - (German) Remux + WEB 2160p.yml
@@ -54,30 +54,20 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
-- name: Radarr - 3D
-  score: -10000
-- name: Radarr - AV1
-  score: -10000
-- name: Radarr - Bad Dual Groups
-  score: -10000
 - name: Radarr - Black and White Editions
-  score: -10000
-- name: Radarr - BR-DISK
-  score: -10000
-- name: Radarr - Extras
-  score: -10000
-- name: Radarr - Generated Dynamic HDR
-  score: -10000
-- name: Radarr - LQ
-  score: -10000
-- name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
   score: -10000
-- name: Radarr - Upscaled
-  score: -10000
-- name: Radarr - x265 (no HDR-DV)
-  score: -10000
+- name: Radarr - 3D
+  score: -35000
+- name: Radarr - AV1
+  score: -35000
+- name: Radarr - Bad Dual Groups
+  score: -35000
+- name: Radarr - BR-DISK
+  score: -35000
+- name: Radarr - Extras
+  score: -35000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)
@@ -86,7 +76,15 @@ custom_formats:
   score: -35000
 - name: Radarr - Line-Mic Dubbed
   score: -35000
+- name: Radarr - LQ
+  score: -35000
+- name: Radarr - LQ (Release Title)
+  score: -35000
 - name: Radarr - Not German or English
+  score: -35000
+- name: Radarr - Upscaled
+  score: -35000
+- name: Radarr - x265 (no HDR-DV)
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Radarr - (German) UHD Bluray + WEB (Alternative).yml
+++ b/profiles/Radarr - (German) UHD Bluray + WEB (Alternative).yml
@@ -63,30 +63,20 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
-- name: Radarr - 3D
-  score: -10000
-- name: Radarr - AV1
-  score: -10000
-- name: Radarr - Bad Dual Groups
-  score: -10000
 - name: Radarr - Black and White Editions
-  score: -10000
-- name: Radarr - BR-DISK
-  score: -10000
-- name: Radarr - Extras
-  score: -10000
-- name: Radarr - Generated Dynamic HDR
-  score: -10000
-- name: Radarr - LQ
-  score: -10000
-- name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
   score: -10000
-- name: Radarr - Upscaled
-  score: -10000
-- name: Radarr - x265 (no HDR-DV)
-  score: -10000
+- name: Radarr - 3D
+  score: -35000
+- name: Radarr - AV1
+  score: -35000
+- name: Radarr - Bad Dual Groups
+  score: -35000
+- name: Radarr - BR-DISK
+  score: -35000
+- name: Radarr - Extras
+  score: -35000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)
@@ -95,7 +85,15 @@ custom_formats:
   score: -35000
 - name: Radarr - Line-Mic Dubbed
   score: -35000
+- name: Radarr - LQ
+  score: -35000
+- name: Radarr - LQ (Release Title)
+  score: -35000
 - name: Radarr - Not German or English
+  score: -35000
+- name: Radarr - Upscaled
+  score: -35000
+- name: Radarr - x265 (no HDR-DV)
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Radarr - (German) UHD Bluray + WEB (Alternative).yml
+++ b/profiles/Radarr - (German) UHD Bluray + WEB (Alternative).yml
@@ -63,6 +63,30 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)

--- a/profiles/Radarr - (German) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (German) UHD Bluray + WEB.yml
@@ -56,30 +56,20 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
-- name: Radarr - 3D
-  score: -10000
-- name: Radarr - AV1
-  score: -10000
-- name: Radarr - Bad Dual Groups
-  score: -10000
 - name: Radarr - Black and White Editions
-  score: -10000
-- name: Radarr - BR-DISK
-  score: -10000
-- name: Radarr - Extras
-  score: -10000
-- name: Radarr - Generated Dynamic HDR
-  score: -10000
-- name: Radarr - LQ
-  score: -10000
-- name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
   score: -10000
-- name: Radarr - Upscaled
-  score: -10000
-- name: Radarr - x265 (no HDR-DV)
-  score: -10000
+- name: Radarr - 3D
+  score: -35000
+- name: Radarr - AV1
+  score: -35000
+- name: Radarr - Bad Dual Groups
+  score: -35000
+- name: Radarr - BR-DISK
+  score: -35000
+- name: Radarr - Extras
+  score: -35000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)
@@ -88,7 +78,15 @@ custom_formats:
   score: -35000
 - name: Radarr - Line-Mic Dubbed
   score: -35000
+- name: Radarr - LQ
+  score: -35000
+- name: Radarr - LQ (Release Title)
+  score: -35000
 - name: Radarr - Not German or English
+  score: -35000
+- name: Radarr - Upscaled
+  score: -35000
+- name: Radarr - x265 (no HDR-DV)
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Radarr - (German) UHD Bluray + WEB.yml
+++ b/profiles/Radarr - (German) UHD Bluray + WEB.yml
@@ -56,6 +56,30 @@ custom_formats:
   score: 5
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 - name: Radarr - German LQ
   score: -35000
 - name: Radarr - German LQ (release title)

--- a/profiles/Radarr - (SQP) SQP-1 (1080p).yml
+++ b/profiles/Radarr - (SQP) SQP-1 (1080p).yml
@@ -52,6 +52,10 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - DTS X
@@ -62,6 +66,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Extras
   score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
@@ -71,6 +77,8 @@ custom_formats:
 - name: Radarr - TrueHD
   score: -10000
 - name: Radarr - TrueHD ATMOS
+  score: -10000
+- name: Radarr - Upscaled
   score: -10000
 - name: Radarr - x265 (HD)
   score: -10000

--- a/profiles/Radarr - (SQP) SQP-1 (2160p).yml
+++ b/profiles/Radarr - (SQP) SQP-1 (2160p).yml
@@ -58,6 +58,10 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - DTS X
@@ -70,6 +74,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Extras
   score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
@@ -79,6 +85,8 @@ custom_formats:
 - name: Radarr - TrueHD
   score: -10000
 - name: Radarr - TrueHD ATMOS
+  score: -10000
+- name: Radarr - Upscaled
   score: -10000
 - name: Radarr - x265 (no HDR-DV)
   score: -10000

--- a/profiles/Radarr - (SQP) SQP-1 WEB (1080p).yml
+++ b/profiles/Radarr - (SQP) SQP-1 WEB (1080p).yml
@@ -54,6 +54,10 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - DTS X
@@ -64,6 +68,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Extras
   score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
@@ -73,6 +79,8 @@ custom_formats:
 - name: Radarr - TrueHD
   score: -10000
 - name: Radarr - TrueHD ATMOS
+  score: -10000
+- name: Radarr - Upscaled
   score: -10000
 - name: Radarr - x265 (HD)
   score: -10000

--- a/profiles/Radarr - (SQP) SQP-1 WEB (2160p).yml
+++ b/profiles/Radarr - (SQP) SQP-1 WEB (2160p).yml
@@ -60,6 +60,10 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - DTS X
@@ -72,6 +76,8 @@ custom_formats:
   score: -10000
 - name: Radarr - Extras
   score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
@@ -81,6 +87,8 @@ custom_formats:
 - name: Radarr - TrueHD
   score: -10000
 - name: Radarr - TrueHD ATMOS
+  score: -10000
+- name: Radarr - Upscaled
   score: -10000
 - name: Radarr - x265 (no HDR-DV)
   score: -10000

--- a/profiles/Radarr - (SQP) SQP-2.yml
+++ b/profiles/Radarr - (SQP) SQP-2.yml
@@ -46,15 +46,25 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
   score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: -1

--- a/profiles/Radarr - (SQP) SQP-3 (Audio).yml
+++ b/profiles/Radarr - (SQP) SQP-3 (Audio).yml
@@ -68,15 +68,25 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
   score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: -1

--- a/profiles/Radarr - (SQP) SQP-3.yml
+++ b/profiles/Radarr - (SQP) SQP-3.yml
@@ -40,15 +40,25 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
   score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: -1

--- a/profiles/Radarr - (SQP) SQP-4 (MA Hybrid).yml
+++ b/profiles/Radarr - (SQP) SQP-4 (MA Hybrid).yml
@@ -70,9 +70,15 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
   score: -10000
 - name: Radarr - LQ
   score: -10000
@@ -80,7 +86,11 @@ custom_formats:
   score: -10000
 - name: Radarr - Sing-Along Versions
   score: -10000
+- name: Radarr - Upscaled
+  score: -10000
 - name: Radarr - Wrong Language
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: -1

--- a/profiles/Radarr - (SQP) SQP-4.yml
+++ b/profiles/Radarr - (SQP) SQP-4.yml
@@ -40,15 +40,25 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
   score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: -1

--- a/profiles/Radarr - (SQP) SQP-5.yml
+++ b/profiles/Radarr - (SQP) SQP-5.yml
@@ -46,15 +46,25 @@ custom_formats:
   score: -10000
 - name: Radarr - AV1
   score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
   score: -10000
 - name: Radarr - LQ
   score: -10000
 - name: Radarr - LQ (Release Title)
   score: -10000
 - name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: -1

--- a/profiles/Radarr - Base Profile.yml
+++ b/profiles/Radarr - Base Profile.yml
@@ -10,9 +10,29 @@ minCustomFormatScore: 0
 upgradeUntilScore: 10000
 minScoreIncrement: 1
 custom_formats:
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
   score: -10000
 - name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: 3

--- a/profiles/Radarr - HD Bluray + WEB.yml
+++ b/profiles/Radarr - HD Bluray + WEB.yml
@@ -26,6 +26,30 @@ custom_formats:
   score: 6
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 qualities:
 - id: 10
   name: Bluray-1080p

--- a/profiles/Radarr - Remux + WEB 1080p.yml
+++ b/profiles/Radarr - Remux + WEB 1080p.yml
@@ -26,6 +26,30 @@ custom_formats:
   score: 6
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (HD)
+  score: -10000
 qualities:
 - id: 8
   name: Remux-1080p

--- a/profiles/Radarr - Remux + WEB 2160p.yml
+++ b/profiles/Radarr - Remux + WEB 2160p.yml
@@ -26,6 +26,30 @@ custom_formats:
   score: 6
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: 3
   name: Remux-2160p

--- a/profiles/Radarr - Remux 2160p (Alternative).yml
+++ b/profiles/Radarr - Remux 2160p (Alternative).yml
@@ -40,6 +40,30 @@ custom_formats:
   score: 6
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: 3
   name: Remux-2160p

--- a/profiles/Radarr - Remux 2160p (Combined).yml
+++ b/profiles/Radarr - Remux 2160p (Combined).yml
@@ -39,6 +39,30 @@ custom_formats:
   score: 6
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
+- name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: 3
   name: Remux-2160p

--- a/profiles/Radarr - UHD Bluray + WEB.yml
+++ b/profiles/Radarr - UHD Bluray + WEB.yml
@@ -26,7 +26,29 @@ custom_formats:
   score: 6
 - name: Radarr - Repack-Proper
   score: 5
+- name: Radarr - 3D
+  score: -10000
+- name: Radarr - AV1
+  score: -10000
+- name: Radarr - Bad Dual Groups
+  score: -10000
+- name: Radarr - Black and White Editions
+  score: -10000
 - name: Radarr - BR-DISK
+  score: -10000
+- name: Radarr - Extras
+  score: -10000
+- name: Radarr - Generated Dynamic HDR
+  score: -10000
+- name: Radarr - LQ
+  score: -10000
+- name: Radarr - LQ (Release Title)
+  score: -10000
+- name: Radarr - Sing-Along Versions
+  score: -10000
+- name: Radarr - Upscaled
+  score: -10000
+- name: Radarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: 4

--- a/profiles/Sonarr - (French MULTi.VF) HD Bluray + WEB (1080p).yml
+++ b/profiles/Sonarr - (French MULTi.VF) HD Bluray + WEB (1080p).yml
@@ -43,6 +43,8 @@ custom_formats:
   score: -10000
 - name: Sonarr - LQ (Release Title)
   score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Sonarr - (French MULTi.VF) UHD Bluray + WEB (2160p).yml
+++ b/profiles/Sonarr - (French MULTi.VF) UHD Bluray + WEB (2160p).yml
@@ -47,6 +47,8 @@ custom_formats:
   score: -10000
 - name: Sonarr - LQ (Release Title)
   score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Sonarr - (French MULTi.VO) HD Bluray + WEB (1080p).yml
+++ b/profiles/Sonarr - (French MULTi.VO) HD Bluray + WEB (1080p).yml
@@ -55,6 +55,8 @@ custom_formats:
   score: -10000
 - name: Sonarr - LQ (Release Title)
   score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Sonarr - (French MULTi.VO) UHD Bluray + WEB (2160p).yml
+++ b/profiles/Sonarr - (French MULTi.VO) UHD Bluray + WEB (2160p).yml
@@ -59,6 +59,8 @@ custom_formats:
   score: -10000
 - name: Sonarr - LQ (Release Title)
   score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Sonarr - (French VOSTFR) HD Bluray + WEB (1080p).yml
+++ b/profiles/Sonarr - (French VOSTFR) HD Bluray + WEB (1080p).yml
@@ -43,6 +43,8 @@ custom_formats:
   score: -10000
 - name: Sonarr - LQ (Release Title)
   score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 1080p

--- a/profiles/Sonarr - (French VOSTFR) UHD Bluray + WEB (2160p).yml
+++ b/profiles/Sonarr - (French VOSTFR) UHD Bluray + WEB (2160p).yml
@@ -47,6 +47,8 @@ custom_formats:
   score: -10000
 - name: Sonarr - LQ (Release Title)
   score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: Bluray|WEB 2160p

--- a/profiles/Sonarr - (German) Anime HD Bluray + WEB.yml
+++ b/profiles/Sonarr - (German) Anime HD Bluray + WEB.yml
@@ -91,6 +91,22 @@ custom_formats:
   score: 1
 - name: Sonarr - v0
   score: -51
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
 - name: Sonarr - Anime LQ Groups
   score: -35000
 - name: Sonarr - Anime Raws

--- a/profiles/Sonarr - (German) Anime HD Bluray + WEB.yml
+++ b/profiles/Sonarr - (German) Anime HD Bluray + WEB.yml
@@ -91,25 +91,19 @@ custom_formats:
   score: 1
 - name: Sonarr - v0
   score: -51
-- name: Sonarr - AV1
-  score: -10000
 - name: Sonarr - Bad Dual Groups
   score: -10000
-- name: Sonarr - BR-DISK
-  score: -10000
 - name: Sonarr - BR-DISK (BTN)
-  score: -10000
-- name: Sonarr - Extras
-  score: -10000
-- name: Sonarr - LQ
-  score: -10000
-- name: Sonarr - LQ (Release Title)
-  score: -10000
-- name: Sonarr - Upscaled
   score: -10000
 - name: Sonarr - Anime LQ Groups
   score: -35000
 - name: Sonarr - Anime Raws
+  score: -35000
+- name: Sonarr - AV1
+  score: -35000
+- name: Sonarr - BR-DISK
+  score: -35000
+- name: Sonarr - Extras
   score: -35000
 - name: Sonarr - German LQ
   score: -35000
@@ -117,7 +111,13 @@ custom_formats:
   score: -35000
 - name: Sonarr - German Microsized
   score: -35000
+- name: Sonarr - LQ
+  score: -35000
+- name: Sonarr - LQ (Release Title)
+  score: -35000
 - name: Sonarr - Not German, Japanese or English
+  score: -35000
+- name: Sonarr - Upscaled
   score: -35000
 - name: Sonarr - VOSTFR
   score: -35000

--- a/profiles/Sonarr - (German) HD Bluray + WEB.yml
+++ b/profiles/Sonarr - (German) HD Bluray + WEB.yml
@@ -51,31 +51,29 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
-- name: Sonarr - AV1
-  score: -10000
-- name: Sonarr - Bad Dual Groups
-  score: -10000
-- name: Sonarr - BR-DISK
-  score: -10000
 - name: Sonarr - BR-DISK (BTN)
   score: -10000
+- name: Sonarr - AV1
+  score: -35000
+- name: Sonarr - Bad Dual Groups
+  score: -35000
+- name: Sonarr - BR-DISK
+  score: -35000
 - name: Sonarr - Extras
-  score: -10000
-- name: Sonarr - LQ
-  score: -10000
-- name: Sonarr - LQ (Release Title)
-  score: -10000
-- name: Sonarr - Upscaled
-  score: -10000
-- name: Sonarr - x265 (HD)
-  score: -10000
+  score: -35000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)
   score: -35000
 - name: Sonarr - German Microsized
   score: -35000
+- name: Sonarr - LQ
+  score: -35000
+- name: Sonarr - LQ (Release Title)
+  score: -35000
 - name: Sonarr - Not German or English
+  score: -35000
+- name: Sonarr - Upscaled
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Sonarr - (German) HD Bluray + WEB.yml
+++ b/profiles/Sonarr - (German) HD Bluray + WEB.yml
@@ -51,6 +51,24 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)

--- a/profiles/Sonarr - (German) HD Remux + WEB.yml
+++ b/profiles/Sonarr - (German) HD Remux + WEB.yml
@@ -44,6 +44,24 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)

--- a/profiles/Sonarr - (German) HD Remux + WEB.yml
+++ b/profiles/Sonarr - (German) HD Remux + WEB.yml
@@ -44,31 +44,29 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
-- name: Sonarr - AV1
-  score: -10000
-- name: Sonarr - Bad Dual Groups
-  score: -10000
-- name: Sonarr - BR-DISK
-  score: -10000
 - name: Sonarr - BR-DISK (BTN)
   score: -10000
+- name: Sonarr - AV1
+  score: -35000
+- name: Sonarr - Bad Dual Groups
+  score: -35000
+- name: Sonarr - BR-DISK
+  score: -35000
 - name: Sonarr - Extras
-  score: -10000
-- name: Sonarr - LQ
-  score: -10000
-- name: Sonarr - LQ (Release Title)
-  score: -10000
-- name: Sonarr - Upscaled
-  score: -10000
-- name: Sonarr - x265 (HD)
-  score: -10000
+  score: -35000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)
   score: -35000
 - name: Sonarr - German Microsized
   score: -35000
+- name: Sonarr - LQ
+  score: -35000
+- name: Sonarr - LQ (Release Title)
+  score: -35000
 - name: Sonarr - Not German or English
+  score: -35000
+- name: Sonarr - Upscaled
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Sonarr - (German) UHD Bluray + WEB (Alternative).yml
+++ b/profiles/Sonarr - (German) UHD Bluray + WEB (Alternative).yml
@@ -55,33 +55,31 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
-- name: Sonarr - AV1
-  score: -10000
-- name: Sonarr - Bad Dual Groups
-  score: -10000
-- name: Sonarr - BR-DISK
-  score: -10000
 - name: Sonarr - BR-DISK (BTN)
   score: -10000
+- name: Sonarr - AV1
+  score: -35000
+- name: Sonarr - Bad Dual Groups
+  score: -35000
+- name: Sonarr - BR-DISK
+  score: -35000
 - name: Sonarr - Extras
-  score: -10000
-- name: Sonarr - LQ
-  score: -10000
-- name: Sonarr - LQ (Release Title)
-  score: -10000
-- name: Sonarr - Upscaled
-  score: -10000
-- name: Sonarr - x265 (HD)
-  score: -10000
-- name: Sonarr - x265 (no HDR-DV)
-  score: -10000
+  score: -35000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)
   score: -35000
 - name: Sonarr - German Microsized
   score: -35000
+- name: Sonarr - LQ
+  score: -35000
+- name: Sonarr - LQ (Release Title)
+  score: -35000
 - name: Sonarr - Not German or English
+  score: -35000
+- name: Sonarr - Upscaled
+  score: -35000
+- name: Sonarr - x265 (no HDR-DV)
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Sonarr - (German) UHD Bluray + WEB (Alternative).yml
+++ b/profiles/Sonarr - (German) UHD Bluray + WEB (Alternative).yml
@@ -55,6 +55,26 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)

--- a/profiles/Sonarr - (German) UHD Bluray + WEB.yml
+++ b/profiles/Sonarr - (German) UHD Bluray + WEB.yml
@@ -50,6 +50,26 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)

--- a/profiles/Sonarr - (German) UHD Bluray + WEB.yml
+++ b/profiles/Sonarr - (German) UHD Bluray + WEB.yml
@@ -50,33 +50,31 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
-- name: Sonarr - AV1
-  score: -10000
-- name: Sonarr - Bad Dual Groups
-  score: -10000
-- name: Sonarr - BR-DISK
-  score: -10000
 - name: Sonarr - BR-DISK (BTN)
   score: -10000
+- name: Sonarr - AV1
+  score: -35000
+- name: Sonarr - Bad Dual Groups
+  score: -35000
+- name: Sonarr - BR-DISK
+  score: -35000
 - name: Sonarr - Extras
-  score: -10000
-- name: Sonarr - LQ
-  score: -10000
-- name: Sonarr - LQ (Release Title)
-  score: -10000
-- name: Sonarr - Upscaled
-  score: -10000
-- name: Sonarr - x265 (HD)
-  score: -10000
-- name: Sonarr - x265 (no HDR-DV)
-  score: -10000
+  score: -35000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)
   score: -35000
 - name: Sonarr - German Microsized
   score: -35000
+- name: Sonarr - LQ
+  score: -35000
+- name: Sonarr - LQ (Release Title)
+  score: -35000
 - name: Sonarr - Not German or English
+  score: -35000
+- name: Sonarr - Upscaled
+  score: -35000
+- name: Sonarr - x265 (no HDR-DV)
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Sonarr - (German) UHD Remux + WEB.yml
+++ b/profiles/Sonarr - (German) UHD Remux + WEB.yml
@@ -48,6 +48,26 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)

--- a/profiles/Sonarr - (German) UHD Remux + WEB.yml
+++ b/profiles/Sonarr - (German) UHD Remux + WEB.yml
@@ -48,33 +48,31 @@ custom_formats:
   score: 5
 - name: Sonarr - Repack-Proper
   score: 5
-- name: Sonarr - AV1
-  score: -10000
-- name: Sonarr - Bad Dual Groups
-  score: -10000
-- name: Sonarr - BR-DISK
-  score: -10000
 - name: Sonarr - BR-DISK (BTN)
   score: -10000
+- name: Sonarr - AV1
+  score: -35000
+- name: Sonarr - Bad Dual Groups
+  score: -35000
+- name: Sonarr - BR-DISK
+  score: -35000
 - name: Sonarr - Extras
-  score: -10000
-- name: Sonarr - LQ
-  score: -10000
-- name: Sonarr - LQ (Release Title)
-  score: -10000
-- name: Sonarr - Upscaled
-  score: -10000
-- name: Sonarr - x265 (HD)
-  score: -10000
-- name: Sonarr - x265 (no HDR-DV)
-  score: -10000
+  score: -35000
 - name: Sonarr - German LQ
   score: -35000
 - name: Sonarr - German LQ (release title)
   score: -35000
 - name: Sonarr - German Microsized
   score: -35000
+- name: Sonarr - LQ
+  score: -35000
+- name: Sonarr - LQ (Release Title)
+  score: -35000
 - name: Sonarr - Not German or English
+  score: -35000
+- name: Sonarr - Upscaled
+  score: -35000
+- name: Sonarr - x265 (no HDR-DV)
   score: -35000
 qualities:
 - id: -1

--- a/profiles/Sonarr - Base Profile.yml
+++ b/profiles/Sonarr - Base Profile.yml
@@ -10,7 +10,27 @@ minCustomFormatScore: 0
 upgradeUntilScore: 10000
 minScoreIncrement: 1
 custom_formats:
+- name: Sonarr - HD Streaming Boost
+  score: 75
+- name: Sonarr - UHD Streaming Boost
+  score: 75
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
 - name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (no HDR-DV)
   score: -10000
 qualities:
 - id: 3

--- a/profiles/Sonarr - WEB-1080p (Alternative).yml
+++ b/profiles/Sonarr - WEB-1080p (Alternative).yml
@@ -17,12 +17,34 @@ custom_formats:
   score: 1600
 - name: Sonarr - WEB Tier 03
   score: 1600
+- name: Sonarr - HD Streaming Boost
+  score: 75
+- name: Sonarr - UHD Streaming Boost
+  score: 75
 - name: Sonarr - Repack3
   score: 7
 - name: Sonarr - Repack2
   score: 6
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
 qualities:
 - id: -1
   name: WEB 1080p

--- a/profiles/Sonarr - WEB-1080p.yml
+++ b/profiles/Sonarr - WEB-1080p.yml
@@ -16,12 +16,34 @@ custom_formats:
   score: 1600
 - name: Sonarr - WEB Tier 03
   score: 1600
+- name: Sonarr - HD Streaming Boost
+  score: 75
+- name: Sonarr - UHD Streaming Boost
+  score: 75
 - name: Sonarr - Repack3
   score: 7
 - name: Sonarr - Repack2
   score: 6
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (HD)
+  score: -10000
 qualities:
 - id: -1
   name: WEB 1080p

--- a/profiles/Sonarr - WEB-2160p (Alternative).yml
+++ b/profiles/Sonarr - WEB-2160p (Alternative).yml
@@ -17,12 +17,34 @@ custom_formats:
   score: 1600
 - name: Sonarr - WEB Tier 03
   score: 1600
+- name: Sonarr - HD Streaming Boost
+  score: 75
+- name: Sonarr - UHD Streaming Boost
+  score: 75
 - name: Sonarr - Repack3
   score: 7
 - name: Sonarr - Repack2
   score: 6
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: WEB 2160p

--- a/profiles/Sonarr - WEB-2160p (Combined).yml
+++ b/profiles/Sonarr - WEB-2160p (Combined).yml
@@ -16,12 +16,34 @@ custom_formats:
   score: 1600
 - name: Sonarr - WEB Tier 03
   score: 1600
+- name: Sonarr - HD Streaming Boost
+  score: 75
+- name: Sonarr - UHD Streaming Boost
+  score: 75
 - name: Sonarr - Repack3
   score: 7
 - name: Sonarr - Repack2
   score: 6
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: WEB 2160p

--- a/profiles/Sonarr - WEB-2160p.yml
+++ b/profiles/Sonarr - WEB-2160p.yml
@@ -16,12 +16,34 @@ custom_formats:
   score: 1600
 - name: Sonarr - WEB Tier 03
   score: 1600
+- name: Sonarr - HD Streaming Boost
+  score: 75
+- name: Sonarr - UHD Streaming Boost
+  score: 75
 - name: Sonarr - Repack3
   score: 7
 - name: Sonarr - Repack2
   score: 6
 - name: Sonarr - Repack-Proper
   score: 5
+- name: Sonarr - AV1
+  score: -10000
+- name: Sonarr - Bad Dual Groups
+  score: -10000
+- name: Sonarr - BR-DISK
+  score: -10000
+- name: Sonarr - BR-DISK (BTN)
+  score: -10000
+- name: Sonarr - Extras
+  score: -10000
+- name: Sonarr - LQ
+  score: -10000
+- name: Sonarr - LQ (Release Title)
+  score: -10000
+- name: Sonarr - Upscaled
+  score: -10000
+- name: Sonarr - x265 (no HDR-DV)
+  score: -10000
 qualities:
 - id: -1
   name: WEB 2160p

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import yaml
+from utils.cf_groups import collect_cf_groups
 from utils.custom_formats import collect_custom_formats
 from utils.media_management import collect_media_management
 from utils.profiles import collect_profiles
@@ -72,14 +73,21 @@ def main():
                 f"Custom format directory {trash_profiles_dir} does not exist, skipping."
             )
             continue
-        trash_id_to_scoring_mapping = collect_custom_formats(
+        trash_id_to_scoring_mapping, trash_id_to_name_mapping = collect_custom_formats(
             service, trash_custom_formats_dir, custom_formats_dir, regex_patterns
         )
+
+        # Collect cf-groups with default flag
+        cf_groups_dir = os.path.join(input_dir, f"{service}/cf-groups")
+        cf_group_additions = collect_cf_groups(service, cf_groups_dir)
+
         collect_profiles(
             service,
             trash_profiles_dir,
             profiles_dir,
             trash_id_to_scoring_mapping,
+            trash_id_to_name_mapping,
+            cf_group_additions,
         )
 
     collect_media_management(input_dir, media_management_dir)

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -87,7 +87,7 @@ def main():
             profiles_dir,
             trash_id_to_scoring_mapping,
             trash_id_to_name_mapping,
-            cf_group_additions,
+            cf_group_additions=cf_group_additions,
         )
 
     collect_media_management(input_dir, media_management_dir)

--- a/scripts/utils/cf_groups.py
+++ b/scripts/utils/cf_groups.py
@@ -31,7 +31,7 @@ def collect_cf_groups(service, cf_groups_dir):
             continue  # No default CFs in this group
 
         # Map to quality profiles
-        for profile_name, profile_trash_id in data.get("quality_profiles", {}).get("include", {}).items():
+        for _profile_name, profile_trash_id in data.get("quality_profiles", {}).get("include", {}).items():
             if profile_trash_id not in profile_to_cfs:
                 profile_to_cfs[profile_trash_id] = []
             profile_to_cfs[profile_trash_id].extend(default_cf_ids)

--- a/scripts/utils/cf_groups.py
+++ b/scripts/utils/cf_groups.py
@@ -1,0 +1,44 @@
+import os
+
+from utils.file_utils import iterate_json_files
+
+
+def collect_cf_groups(service, cf_groups_dir):
+    """
+    Collect default CF-groups and map to quality profiles.
+
+    Returns:
+        dict[profile_trash_id, list[cf_trash_id]]: Mapping of profiles to additional CFs
+    """
+    if not os.path.exists(cf_groups_dir):
+        print(f"CF-groups directory {cf_groups_dir} does not exist, skipping.")
+        return {}
+
+    profile_to_cfs = {}  # {profile_trash_id: [cf_trash_id, ...]}
+
+    for _, _, data in iterate_json_files(cf_groups_dir):
+        # Check group-level default
+        if data.get("default") != "true":
+            continue
+
+        # Collect CFs with CF-level default
+        default_cf_ids = []
+        for cf in data.get("custom_formats", []):
+            if cf.get("default") is True:  # Note: boolean, not string
+                default_cf_ids.append(cf["trash_id"])
+
+        if not default_cf_ids:
+            continue  # No default CFs in this group
+
+        # Map to quality profiles
+        for profile_name, profile_trash_id in data.get("quality_profiles", {}).get("include", {}).items():
+            if profile_trash_id not in profile_to_cfs:
+                profile_to_cfs[profile_trash_id] = []
+            profile_to_cfs[profile_trash_id].extend(default_cf_ids)
+
+    # Deduplicate CF lists per profile
+    for profile_id in profile_to_cfs:
+        profile_to_cfs[profile_id] = list(set(profile_to_cfs[profile_id]))
+
+    print(f"Collected {len(profile_to_cfs)} profiles with default CF-groups for {service}")
+    return profile_to_cfs

--- a/scripts/utils/custom_formats.py
+++ b/scripts/utils/custom_formats.py
@@ -135,14 +135,17 @@ def _collect_custom_format(
 
 def collect_custom_formats(service, input_dir, output_dir, custom_regex_patterns):
     trash_id_to_scoring_mapping = {}
+    trash_id_to_name_mapping = {}
     for _, file_stem, data in iterate_json_files(input_dir):
         trash_id = data.get("trash_id")
+        name = data.get("name")
         trash_scores = data.get("trash_scores", {})
         if trash_id:
             trash_id_to_scoring_mapping[trash_id] = trash_scores
+            trash_id_to_name_mapping[trash_id] = name
 
         _collect_custom_format(
             service, file_stem, data, output_dir, custom_regex_patterns
         )
 
-    return trash_id_to_scoring_mapping
+    return trash_id_to_scoring_mapping, trash_id_to_name_mapping

--- a/scripts/utils/profiles.py
+++ b/scripts/utils/profiles.py
@@ -12,7 +12,7 @@ def _collect_profile_formats(
     service, trash_score_name, format_items, trash_id_to_scoring_mapping, trash_id_to_name_mapping
 ):
     profile_formats = []
-    for name, trash_id in format_items.items():
+    for _name, trash_id in format_items.items():
         scoring = trash_id_to_scoring_mapping[trash_id]
         score = scoring.get(trash_score_name, scoring.get("default", 0))
         if score == 0:
@@ -84,60 +84,40 @@ def _get_upgrade_until(quality_name, profile_qualities):
     return found_quality
 
 
-def _collect_profile(service, input_json, output_dir, trash_id_to_scoring_mapping, trash_id_to_name_mapping, cf_group_additions=None):
-    # Compose YAML structure
-    name = input_json.get("name", "")
-    profile_trash_id = input_json.get("trash_id")
-    profile_score_set = input_json.get("trash_score_set")
-    profile_qualities = _collect_qualities(service, input_json.get("items", []))
+def _merge_cf_group_additions(
+    service, profile_score_set, profile_formats, cf_trash_ids, *,
+    trash_id_to_scoring_mapping, trash_id_to_name_mapping
+):
+    """Merge CF group additions into profile formats list."""
+    existing_cf_names = {fmt["name"] for fmt in profile_formats}
+    additional_formats = []
 
-    # Collect mandatory formats from formatItems
-    profile_formats = _collect_profile_formats(
-        service,
-        input_json.get("trash_score_set"),
-        input_json.get("formatItems", {}),
-        trash_id_to_scoring_mapping,
-        trash_id_to_name_mapping,
+    for cf_trash_id in cf_trash_ids:
+        if cf_trash_id not in trash_id_to_name_mapping:
+            continue
+
+        cf_name = get_name(service, trash_id_to_name_mapping[cf_trash_id])
+        if cf_name in existing_cf_names:
+            continue
+
+        scoring = trash_id_to_scoring_mapping.get(cf_trash_id, {})
+        score = scoring.get(profile_score_set, scoring.get("default", 0))
+        if score == 0:
+            continue
+
+        additional_formats.append({"name": cf_name, "score": score})
+
+    return sorted(
+        profile_formats + additional_formats,
+        key=lambda fmt: (-fmt["score"], fmt["name"].lower()),
+        reverse=False,
     )
 
-    # Merge cf-group additions
-    if cf_group_additions and profile_trash_id in cf_group_additions:
-        # Build set of existing CF names for deduplication
-        existing_cf_names = {fmt["name"] for fmt in profile_formats}
 
-        for cf_trash_id in cf_group_additions[profile_trash_id]:
-            # Skip if CF not in mappings (shouldn't happen but safety check)
-            if cf_trash_id not in trash_id_to_name_mapping:
-                continue
-
-            cf_name = get_name(service, trash_id_to_name_mapping[cf_trash_id])
-
-            # Skip if already present (from formatItems)
-            if cf_name in existing_cf_names:
-                continue
-
-            # Get score from CF definition
-            scoring = trash_id_to_scoring_mapping.get(cf_trash_id, {})
-            score = scoring.get(profile_score_set, scoring.get("default", 0))
-
-            # Skip if no score
-            if score == 0:
-                continue
-
-            profile_formats.append({"name": cf_name, "score": score})
-
-        # Re-sort after merging
-        profile_formats = sorted(
-            profile_formats,
-            key=lambda profile_format: (
-                -profile_format["score"],
-                profile_format["name"].lower(),
-            ),
-            reverse=False,
-        )
-
-    yml_data = {
-        "name": get_name(service, name),
+def _build_profile_yaml_data(service, input_json, profile_formats, profile_qualities):
+    """Build the YAML data structure for a profile."""
+    return {
+        "name": get_name(service, input_json.get("name", "")),
         "description": f"""[Profile from TRaSH-Guides.](https://trash-guides.info/{service.capitalize()}/{service}-setup-quality-profiles)
 
 {markdownify(input_json.get('trash_description', ''))}""".strip(),
@@ -152,8 +132,32 @@ def _collect_profile(service, input_json, output_dir, trash_id_to_scoring_mappin
         "language": input_json.get("language", "any").lower(),
     }
 
-    # Output path
-    output_path = os.path.join(output_dir, f"{get_name(service, name)}.yml")
+
+def _collect_profile(
+    service, input_json, output_dir, trash_id_to_scoring_mapping, trash_id_to_name_mapping, *, cf_group_additions=None
+):
+    profile_trash_id = input_json.get("trash_id")
+    profile_score_set = input_json.get("trash_score_set")
+    profile_qualities = _collect_qualities(service, input_json.get("items", []))
+
+    profile_formats = _collect_profile_formats(
+        service,
+        profile_score_set,
+        input_json.get("formatItems", {}),
+        trash_id_to_scoring_mapping,
+        trash_id_to_name_mapping,
+    )
+
+    if cf_group_additions and profile_trash_id in cf_group_additions:
+        profile_formats = _merge_cf_group_additions(
+            service, profile_score_set, profile_formats, cf_group_additions[profile_trash_id],
+            trash_id_to_scoring_mapping=trash_id_to_scoring_mapping,
+            trash_id_to_name_mapping=trash_id_to_name_mapping
+        )
+
+    yml_data = _build_profile_yaml_data(service, input_json, profile_formats, profile_qualities)
+
+    output_path = os.path.join(output_dir, f"{get_name(service, input_json.get('name', ''))}.yml")
     with open(output_path, "w", encoding="utf-8") as f:
         yaml.dump(yml_data, f, sort_keys=False, allow_unicode=True)
     print(f"Generated: {output_path}")
@@ -165,7 +169,11 @@ def collect_profiles(
     output_dir,
     trash_id_to_scoring_mapping,
     trash_id_to_name_mapping,
+    *,
     cf_group_additions=None,
 ):
     for _, _, data in iterate_json_files(input_dir):
-        _collect_profile(service, data, output_dir, trash_id_to_scoring_mapping, trash_id_to_name_mapping, cf_group_additions)
+        _collect_profile(
+            service, data, output_dir, trash_id_to_scoring_mapping, trash_id_to_name_mapping,
+            cf_group_additions=cf_group_additions
+        )

--- a/scripts/utils/profiles.py
+++ b/scripts/utils/profiles.py
@@ -88,6 +88,7 @@ def _collect_profile(service, input_json, output_dir, trash_id_to_scoring_mappin
     # Compose YAML structure
     name = input_json.get("name", "")
     profile_trash_id = input_json.get("trash_id")
+    profile_score_set = input_json.get("trash_score_set")
     profile_qualities = _collect_qualities(service, input_json.get("items", []))
 
     # Collect mandatory formats from formatItems
@@ -117,9 +118,9 @@ def _collect_profile(service, input_json, output_dir, trash_id_to_scoring_mappin
 
             # Get score from CF definition
             scoring = trash_id_to_scoring_mapping.get(cf_trash_id, {})
-            score = scoring.get("default", 0)
+            score = scoring.get(profile_score_set, scoring.get("default", 0))
 
-            # Skip if no default score
+            # Skip if no score
             if score == 0:
                 continue
 

--- a/scripts/utils/profiles.py
+++ b/scripts/utils/profiles.py
@@ -9,7 +9,7 @@ from utils.strings import get_name
 
 
 def _collect_profile_formats(
-    service, trash_score_name, format_items, trash_id_to_scoring_mapping
+    service, trash_score_name, format_items, trash_id_to_scoring_mapping, trash_id_to_name_mapping
 ):
     profile_formats = []
     for name, trash_id in format_items.items():
@@ -18,7 +18,8 @@ def _collect_profile_formats(
         if score == 0:
             continue
 
-        profile_formats.append({"name": get_name(service, name), "score": score})
+        cf_name = trash_id_to_name_mapping[trash_id]
+        profile_formats.append({"name": get_name(service, cf_name), "score": score})
     return sorted(
         profile_formats,
         key=lambda profile_format: (
@@ -83,10 +84,57 @@ def _get_upgrade_until(quality_name, profile_qualities):
     return found_quality
 
 
-def _collect_profile(service, input_json, output_dir, trash_id_to_scoring_mapping):
+def _collect_profile(service, input_json, output_dir, trash_id_to_scoring_mapping, trash_id_to_name_mapping, cf_group_additions=None):
     # Compose YAML structure
     name = input_json.get("name", "")
+    profile_trash_id = input_json.get("trash_id")
     profile_qualities = _collect_qualities(service, input_json.get("items", []))
+
+    # Collect mandatory formats from formatItems
+    profile_formats = _collect_profile_formats(
+        service,
+        input_json.get("trash_score_set"),
+        input_json.get("formatItems", {}),
+        trash_id_to_scoring_mapping,
+        trash_id_to_name_mapping,
+    )
+
+    # Merge cf-group additions
+    if cf_group_additions and profile_trash_id in cf_group_additions:
+        # Build set of existing CF names for deduplication
+        existing_cf_names = {fmt["name"] for fmt in profile_formats}
+
+        for cf_trash_id in cf_group_additions[profile_trash_id]:
+            # Skip if CF not in mappings (shouldn't happen but safety check)
+            if cf_trash_id not in trash_id_to_name_mapping:
+                continue
+
+            cf_name = get_name(service, trash_id_to_name_mapping[cf_trash_id])
+
+            # Skip if already present (from formatItems)
+            if cf_name in existing_cf_names:
+                continue
+
+            # Get score from CF definition
+            scoring = trash_id_to_scoring_mapping.get(cf_trash_id, {})
+            score = scoring.get("default", 0)
+
+            # Skip if no default score
+            if score == 0:
+                continue
+
+            profile_formats.append({"name": cf_name, "score": score})
+
+        # Re-sort after merging
+        profile_formats = sorted(
+            profile_formats,
+            key=lambda profile_format: (
+                -profile_format["score"],
+                profile_format["name"].lower(),
+            ),
+            reverse=False,
+        )
+
     yml_data = {
         "name": get_name(service, name),
         "description": f"""[Profile from TRaSH-Guides.](https://trash-guides.info/{service.capitalize()}/{service}-setup-quality-profiles)
@@ -97,12 +145,7 @@ def _collect_profile(service, input_json, output_dir, trash_id_to_scoring_mappin
         "minCustomFormatScore": input_json.get("minFormatScore", 0),
         "upgradeUntilScore": input_json.get("cutoffFormatScore", 0),
         "minScoreIncrement": input_json.get("minUpgradeFormatScore", 0),
-        "custom_formats": _collect_profile_formats(
-            service,
-            input_json.get("trash_score_set"),
-            input_json.get("formatItems", {}),
-            trash_id_to_scoring_mapping,
-        ),
+        "custom_formats": profile_formats,
         "qualities": profile_qualities,
         "upgrade_until": _get_upgrade_until(input_json.get("cutoff"), profile_qualities),
         "language": input_json.get("language", "any").lower(),
@@ -120,6 +163,8 @@ def collect_profiles(
     input_dir,
     output_dir,
     trash_id_to_scoring_mapping,
+    trash_id_to_name_mapping,
+    cf_group_additions=None,
 ):
     for _, _, data in iterate_json_files(input_dir):
-        _collect_profile(service, data, output_dir, trash_id_to_scoring_mapping)
+        _collect_profile(service, data, output_dir, trash_id_to_scoring_mapping, trash_id_to_name_mapping, cf_group_additions)


### PR DESCRIPTION
In https://github.com/johman10/profilarr-trash-guides/commit/9d6ade70d0a4d8fa1e488481450922d71af4b54a#diff-511563831413fe37915a11922db08fc9d14c4c06d523cd97a86099b0789ddda7 the unwanted custom formats were removed as per https://github.com/TRaSH-Guides/Guides/commit/23b38abb05f1dda4132c7505ab20a7ccc7c0229d.

It seems like TRaSH-Guides is now depending more on the custom format groups.

This PR adds processing of these format groups to ensure the resulting profiles are still correct and accurate. If a cf-group is marked as with `"default": "true"` and the custom format within is marked with `"default": true` it will automatically be added.

Profilarr does not really support custom format groups - so if someone wants to add an optional group they will have to add them manually. If there is an interest I could in the future setup an automation for a branch that will add it or some instructions on how to fork and include a custom format.